### PR TITLE
Introduce globally registering things

### DIFF
--- a/apps/jamtools/core/engine/register.ts
+++ b/apps/jamtools/core/engine/register.ts
@@ -19,7 +19,7 @@ type ModuleAPI = {
     states: StatesAPI;
 }
 
-type MacroOptions = {};
+export type MacroOptions = {};
 
 type SnackAPI = {
     createMacro(macroName: string, options: MacroOptions): Promise<void>;

--- a/apps/jamtools/core/engine/register.ts
+++ b/apps/jamtools/core/engine/register.ts
@@ -1,0 +1,73 @@
+import {Module} from '~/module_registry/module_registry';
+import {CoreDependencies, ModuleDependencies} from '~/types/module_types';
+
+type RegisterRouteOptions = {};
+type RegisterSnackOptions = {};
+type SnackCallback = (snackAPI: SnackAPI) => Promise<void>;
+
+type StatesAPI = {
+    createSharedState(stateName: string): void;
+    createSessionState(stateName: string): void;
+    createPersistentState(stateName: string): void;
+    createLocalState(stateName: string): void;
+    createLocalStorageState(stateName: string): void;
+}
+
+type ModuleAPI = {
+    registerRoute(routePath: string, options: RegisterRouteOptions, component: React.ElementType): void;
+    registerSnack(snackName: string, options: RegisterSnackOptions, cb: SnackCallback): Promise<void>;
+    states: StatesAPI;
+}
+
+type MacroOptions = {};
+
+type SnackAPI = {
+    createMacro(macroName: string, options: MacroOptions): Promise<void>;
+    states: StatesAPI;
+}
+
+export type ModuleCallback<ModuleReturnValue extends object> = (moduleAPI: ModuleAPI) =>
+    Promise<ModuleReturnValue> | ModuleReturnValue;
+
+export type ClassModuleCallback<T extends object> = (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) =>
+Promise<Module<T>> | Module<T>;
+
+export type JamTools = {
+    registerModule: <ModuleOptions extends RegisterModuleOptions, ModuleReturnValue extends object>(
+        moduleName: string,
+        options: ModuleOptions,
+        cb: ModuleCallback<ModuleReturnValue>,
+    ) => void;
+    registerClassModule: <T extends object>(cb: ClassModuleCallback<T>) => void;
+};
+
+export type RegisterModuleOptions = {
+
+};
+
+type CapturedRegisterModuleCalls = [string, RegisterModuleOptions, ModuleCallback<any>];
+
+const registerModule = <ModuleOptions extends RegisterModuleOptions, ModuleReturnValue extends object>(
+    moduleName: string,
+    options: ModuleOptions,
+    cb: ModuleCallback<ModuleReturnValue>,
+) => {
+    const calls = (registerModule as unknown as {calls: CapturedRegisterModuleCalls[]}).calls || [];
+    calls.push([moduleName, options, cb]);
+    (registerModule as unknown as {calls: CapturedRegisterModuleCalls[]}).calls = calls;
+}
+
+type CapturedRegisterClassModuleCalls = ClassModuleCallback<any>;
+
+const registerClassModule = <T extends object>(cb: ClassModuleCallback<T>) => {
+    const calls = (registerClassModule as unknown as {calls: CapturedRegisterClassModuleCalls[]}).calls || [];
+    calls.push(cb);
+    (registerClassModule as unknown as {calls: CapturedRegisterClassModuleCalls[]}).calls = calls;
+}
+
+export const jamtools: JamTools = {
+    registerModule,
+    registerClassModule,
+};
+
+(globalThis as unknown as {jamtools: JamTools}).jamtools = jamtools;

--- a/apps/jamtools/core/engine/register.ts
+++ b/apps/jamtools/core/engine/register.ts
@@ -27,7 +27,7 @@ type SnackAPI = {
 }
 
 export type ModuleCallback<ModuleReturnValue extends object> = (moduleAPI: ModuleAPI) =>
-    Promise<ModuleReturnValue> | ModuleReturnValue;
+Promise<ModuleReturnValue> | ModuleReturnValue;
 
 export type ClassModuleCallback<T extends object> = (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) =>
 Promise<Module<T>> | Module<T>;
@@ -55,7 +55,7 @@ const registerModule = <ModuleOptions extends RegisterModuleOptions, ModuleRetur
     const calls = (registerModule as unknown as {calls: CapturedRegisterModuleCalls[]}).calls || [];
     calls.push([moduleName, options, cb]);
     (registerModule as unknown as {calls: CapturedRegisterModuleCalls[]}).calls = calls;
-}
+};
 
 type CapturedRegisterClassModuleCalls = ClassModuleCallback<any>;
 
@@ -63,7 +63,7 @@ const registerClassModule = <T extends object>(cb: ClassModuleCallback<T>) => {
     const calls = (registerClassModule as unknown as {calls: CapturedRegisterClassModuleCalls[]}).calls || [];
     calls.push(cb);
     (registerClassModule as unknown as {calls: CapturedRegisterClassModuleCalls[]}).calls = calls;
-}
+};
 
 export const jamtools: JamTools = {
     registerModule,

--- a/apps/jamtools/core/module_registry/module_registry.tsx
+++ b/apps/jamtools/core/module_registry/module_registry.tsx
@@ -1,12 +1,7 @@
 import React, {useEffect, useState} from 'react';
 
 import {Subject} from 'rxjs';
-import {HelloModule} from '~/modules/hello/hello_module';
-import {IoModule} from '~/modules/io/io_module';
-import {MacroModule} from '~/modules/macro_module/macro_module';
 import {MacroModuleClient} from '~/modules/macro_module/macro_module_types';
-import {MidiThruModule} from '~/modules/midi_playback/basic_midi_thru/basic_midi_thru_module';
-import {WledModule} from '~/modules/wled/wled_module';
 
 export type Module<State extends object = any> = {
     moduleId: string;
@@ -17,13 +12,9 @@ export type Module<State extends object = any> = {
     routes?: Record<string, React.ElementType>;
 } & Partial<MacroModuleClient<any>>
 
-export type AllModules = {
-    hello: HelloModule;
-    io: IoModule;
-    wled: WledModule;
-    macro: MacroModule;
-    midiThru: MidiThruModule;
-}
+// this interface is meant to be extended by each individual module file through interface merging
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface AllModules {}
 
 type ModuleMap = {[moduleId: string]: Module};
 

--- a/apps/jamtools/core/modules/hello/hello_module.tsx
+++ b/apps/jamtools/core/modules/hello/hello_module.tsx
@@ -2,7 +2,7 @@ import React, {createContext} from 'react';
 
 import {Subject} from 'rxjs';
 
-import {CoreDependencies, ModuleDependencies} from '~/types/module_types';
+import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_types';
 import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 
@@ -16,10 +16,23 @@ type HelloHookValue = ModuleHookValue<HelloModule>;
 
 const helloContext = createContext<HelloHookValue>({} as HelloHookValue);
 
+setTimeout(() => {
+    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
+        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+            return new HelloModule(coreDeps, modDependencies);
+        });
+});
+
+declare module '~/module_registry/module_registry' {
+    interface AllModules {
+        hello: HelloModule;
+    }
+}
+
 export class HelloModule implements Module<HelloState> {
     moduleId = 'hello';
 
-    enabled = false;
+    // enabled = false;
 
     routes: Record<string, React.ElementType> = {
         '': HelloComponent,

--- a/apps/jamtools/core/modules/hello/hello_module.tsx
+++ b/apps/jamtools/core/modules/hello/hello_module.tsx
@@ -7,6 +7,7 @@ import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 
 import {HelloComponent} from './hello_component';
+import {jamtools} from '~/engine/register';
 
 type HelloState = {
     hello: boolean;
@@ -16,11 +17,8 @@ type HelloHookValue = ModuleHookValue<HelloModule>;
 
 const helloContext = createContext<HelloHookValue>({} as HelloHookValue);
 
-setTimeout(() => {
-    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
-        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
-            return new HelloModule(coreDeps, modDependencies);
-        });
+jamtools.registerClassModule((coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+    return new HelloModule(coreDeps, modDependencies);
 });
 
 declare module '~/module_registry/module_registry' {

--- a/apps/jamtools/core/modules/io/io_module.tsx
+++ b/apps/jamtools/core/modules/io/io_module.tsx
@@ -6,6 +6,7 @@ import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_typ
 import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 import {MidiInputEventPayload, QwertyCallbackPayload} from '~/types/io_types';
+import {jamtools} from '~/engine/register';
 
 type IoState = {
     midiInputDevices: string[];
@@ -16,11 +17,8 @@ type IoHookValue = ModuleHookValue<IoModule>;
 
 const ioContext = createContext<IoHookValue>({} as IoHookValue);
 
-setTimeout(() => {
-    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
-        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
-            return new IoModule(coreDeps, modDependencies);
-        });
+jamtools.registerClassModule((coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+    return new IoModule(coreDeps, modDependencies);
 });
 
 declare module '~/module_registry/module_registry' {

--- a/apps/jamtools/core/modules/io/io_module.tsx
+++ b/apps/jamtools/core/modules/io/io_module.tsx
@@ -2,7 +2,7 @@ import React, {createContext} from 'react';
 
 import {Subject} from 'rxjs';
 
-import {CoreDependencies, ModuleDependencies} from '~/types/module_types';
+import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_types';
 import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 import {MidiInputEventPayload, QwertyCallbackPayload} from '~/types/io_types';
@@ -15,6 +15,19 @@ type IoState = {
 type IoHookValue = ModuleHookValue<IoModule>;
 
 const ioContext = createContext<IoHookValue>({} as IoHookValue);
+
+setTimeout(() => {
+    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
+        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+            return new IoModule(coreDeps, modDependencies);
+        });
+});
+
+declare module '~/module_registry/module_registry' {
+    interface AllModules {
+        io: IoModule;
+    }
+}
 
 export class IoModule implements Module<IoState> {
     moduleId = 'io';

--- a/apps/jamtools/core/modules/macro_module/macro_handlers/musical_keyboard_input_macro_handler.tsx
+++ b/apps/jamtools/core/modules/macro_module/macro_handlers/musical_keyboard_input_macro_handler.tsx
@@ -27,6 +27,12 @@ const useSubject = <T,>(initialData: T, subject: Subject<T>) => {
     return state;
 };
 
+declare module '~/modules/macro_module/macro_module_types' {
+    interface ProducedTypeMap {
+        musical_keyboard_input: MusicalKeyboardInputHandler;
+    }
+}
+
 export class MusicalKeyboardInputHandler {
     configuredMappings: MidiDeviceAndChannelMap<boolean> = {};
 

--- a/apps/jamtools/core/modules/macro_module/macro_module.tsx
+++ b/apps/jamtools/core/modules/macro_module/macro_module.tsx
@@ -8,6 +8,7 @@ import {Subject} from 'rxjs';
 import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {MacroPage} from './macro_page';
 import {SoundfontPeripheral} from '~/peripherals/outputs/soundfont_peripheral';
+import {jamtools} from '~/engine/register';
 
 type ModuleId = string;
 
@@ -20,11 +21,8 @@ type MacroHookValue = ModuleHookValue<MacroModule>;
 
 const macroContext = React.createContext<MacroHookValue>({} as MacroHookValue);
 
-setTimeout(() => {
-    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
-        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
-            return new MacroModule(coreDeps, modDependencies);
-        });
+jamtools.registerClassModule((coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+    return new MacroModule(coreDeps, modDependencies);
 });
 
 declare module '~/module_registry/module_registry' {
@@ -36,9 +34,7 @@ declare module '~/module_registry/module_registry' {
 export class MacroModule implements Module<MacroConfigState> {
     moduleId = 'macro';
 
-    constructor(private coreDeps: CoreDependencies, private moduleDeps: ModuleDependencies) {
-        // this.musicalKeyboardHandler = new MusicalKeyboardInputHandler(coreDeps, moduleDeps);
-    }
+    constructor(private coreDeps: CoreDependencies, private moduleDeps: ModuleDependencies) {}
 
     routes = {
         '': () => {

--- a/apps/jamtools/core/modules/macro_module/macro_module.tsx
+++ b/apps/jamtools/core/modules/macro_module/macro_module.tsx
@@ -101,12 +101,12 @@ export class MacroModule implements Module<MacroConfigState> {
             switch (conf.type) {
                 case 'musical_keyboard_input': {
                     const handler: ProducedType<typeof conf> = new MusicalKeyboardInputHandler(moduleId, fieldName, this.coreDeps, this.moduleDeps, conf);
-                    producedMacros[fname] = handler as ProducedTypeMap<T[keyof T]['type']>;
+                    producedMacros[fname] = handler as ProducedTypeMap[T[keyof T]['type']];
                     await handler.initialize();
                     break;
                 } case 'musical_keyboard_output': {
                     const handler: ProducedType<typeof conf> = new SoundfontPeripheral(this.coreDeps, this.moduleDeps);
-                    producedMacros[fname] = handler as ProducedTypeMap<T[keyof T]['type']>;
+                    producedMacros[fname] = handler as ProducedTypeMap[T[keyof T]['type']];
                     await handler.initialize?.();
                     break;
                 } default:

--- a/apps/jamtools/core/modules/macro_module/macro_module_types.ts
+++ b/apps/jamtools/core/modules/macro_module/macro_module_types.ts
@@ -1,5 +1,5 @@
 import {MIDI_NUMBER_TO_NOTE_NAME_MAPPINGS} from '~/constants/midi_number_to_note_name_mappings';
-import type {MusicalKeyboardInputHandler} from './macro_handlers/musical_keyboard_input_macro_handler';
+import {MacroOptions} from '~/engine/register';
 
 export type MidiDeviceAndChannel = {
     device: string;
@@ -66,23 +66,35 @@ export interface OutputMidiDevice {
     initialize?: () => Promise<void>;
 }
 
-type MacroTypes = 'musical_keyboard_input' | 'musical_keyboard_output';
+// this interface is meant to be extended by each individual macro type through interface merging
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ProducedTypeMap {}
 
-export type ProducedTypeMap<T extends string> =
-  T extends 'musical_keyboard_input' ? MusicalKeyboardInputHandler :
-      T extends 'musical_keyboard_output' ? OutputMidiDevice:
-          never;
+export type ProducedType<T extends keyof ProducedTypeMap> = ProducedTypeMap[T];
 
-export type ProducedType<T extends MacroConfigItem> = ProducedTypeMap<T['type']>;
-
-export type ProducedTypeFromTypeString<T extends MacroTypes> = ProducedTypeMap<T>;
+export type ProducedTypeFromTypeString<T extends keyof ProducedTypeMap> = ProducedTypeMap[T];
 
 export function stubProducedMacros<T extends RegisteredMacroConfigItems >(
     config: T
-): { [K in keyof T]: ProducedType<T[K]> } {
+): { [K in keyof T]: ProducedType<T[K]['type']> } {
     const result = {} as { [K in keyof T]: ProducedType<T[K]> };
     return result;
 }
+
+const createMacro = async <MacroType extends keyof ProducedTypeMap>(
+    macroName: string,
+    macroType: MacroType,
+    macroOptions: MacroOptions
+): Promise<ProducedTypeMap[MacroType]> => {
+    return {} as ProducedTypeMap[MacroType];
+};
+
+// just testing out the api types
+// setTimeout(async () => {
+//     const myMacro = await createMacro('yo', 'musical_keyboard_input', {});
+//     myMacro.onEventSubject.subscribe
+//     const myMacro2 = await createMacro('yo', 'musical_keyboard_output', {});
+// });
 
 export type FullInputConfig = {
     [fieldName: string]: MacroConfigItem;
@@ -91,13 +103,3 @@ export type FullInputConfig = {
 export type FullProducedOutput<T extends FullInputConfig> = {
     [K in keyof T]: ProducedType<T[K]>;
 }
-
-
-// how do I structure the directories to differentiate between plumbing modules and feature modules?
-// plumbing, porcelain, feature
-
-// I think the macro module will need to be aware of the other modules types
-// so it knows about all of the available config things. like assigning chord families to things
-// a porcelain module "chord_family_commander" provides a way to register combos of midi instruments and chord families in the macro module UI
-// then a feature module just needs to declare a macro config item of type "chord_family_output", and it will be given a function to send a chord identifier to be played
-// as well as provide an "all notes off" functionality, so you can do staccato stuff

--- a/apps/jamtools/core/modules/midi_playback/basic_midi_thru/basic_midi_thru_module.tsx
+++ b/apps/jamtools/core/modules/midi_playback/basic_midi_thru/basic_midi_thru_module.tsx
@@ -7,22 +7,19 @@ import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_typ
 import {BaseModule, ModuleHookValue} from '../../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 import {MacroModuleClient, MidiDeviceAndChannel, MidiDeviceAndChannelMap, MidiEventFull, ProducedType, RegisteredMacroConfigItems, convertMidiNumberToNoteAndOctave, stubProducedMacros} from '~/modules/macro_module/macro_module_types';
+import {jamtools} from '~/engine/register';
 
 type MidiThruState = {
     inputDevice?: MidiDeviceAndChannel;
     outputDevice?: MidiDeviceAndChannel;
 };
 
-
 type MidiThruHookValue = ModuleHookValue<MidiThruModule>;
 
 const midiThruContext = createContext<MidiThruHookValue>({} as MidiThruHookValue);
 
-setTimeout(() => {
-    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
-        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
-            return new MidiThruModule(coreDeps, modDependencies);
-        });
+jamtools.registerClassModule((coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+    return new MidiThruModule(coreDeps, modDependencies);
 });
 
 declare module '~/module_registry/module_registry' {

--- a/apps/jamtools/core/modules/midi_playback/basic_midi_thru/basic_midi_thru_module.tsx
+++ b/apps/jamtools/core/modules/midi_playback/basic_midi_thru/basic_midi_thru_module.tsx
@@ -3,7 +3,7 @@ import {Subject} from 'rxjs';
 
 import Soundfont from 'soundfont-player';
 
-import {CoreDependencies, ModuleDependencies} from '~/types/module_types';
+import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_types';
 import {BaseModule, ModuleHookValue} from '../../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 import {MacroModuleClient, MidiDeviceAndChannel, MidiDeviceAndChannelMap, MidiEventFull, ProducedType, RegisteredMacroConfigItems, convertMidiNumberToNoteAndOctave, stubProducedMacros} from '~/modules/macro_module/macro_module_types';
@@ -17,6 +17,19 @@ type MidiThruState = {
 type MidiThruHookValue = ModuleHookValue<MidiThruModule>;
 
 const midiThruContext = createContext<MidiThruHookValue>({} as MidiThruHookValue);
+
+setTimeout(() => {
+    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
+        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+            return new MidiThruModule(coreDeps, modDependencies);
+        });
+});
+
+declare module '~/module_registry/module_registry' {
+    interface AllModules {
+        basic_midi_thru: MidiThruModule;
+    }
+}
 
 export class MidiThruModule implements Module<MidiThruState>, MacroModuleClient<MidiThruModule['macroConfig']> {
     moduleId = 'basic_midi_thru';

--- a/apps/jamtools/core/modules/wled/wled_module.tsx
+++ b/apps/jamtools/core/modules/wled/wled_module.tsx
@@ -2,7 +2,7 @@ import React, {createContext} from 'react';
 
 import {Subject, Subscription} from 'rxjs';
 
-import {CoreDependencies, ModuleDependencies} from '~/types/module_types';
+import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_types';
 import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 import {WLEDClient} from 'wled-client';
@@ -24,6 +24,19 @@ type WledState = {
 type WledHookValue = ModuleHookValue<WledModule>;
 
 const WledContext = createContext<WledHookValue>({} as WledHookValue);
+
+setTimeout(() => {
+    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
+        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+            return new WledModule(coreDeps, modDependencies);
+        });
+});
+
+declare module '~/module_registry/module_registry' {
+    interface AllModules {
+        wled: WledModule;
+    }
+}
 
 export class WledModule implements Module<WledState> {
     moduleId = 'wled';

--- a/apps/jamtools/core/modules/wled/wled_module.tsx
+++ b/apps/jamtools/core/modules/wled/wled_module.tsx
@@ -6,6 +6,7 @@ import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_typ
 import {BaseModule, ModuleHookValue} from '../base_module/base_module';
 import {Module} from '~/module_registry/module_registry';
 import {WLEDClient} from 'wled-client';
+import {jamtools} from '~/engine/register';
 
 type WledClientStatus = {
     url: string;
@@ -25,11 +26,8 @@ type WledHookValue = ModuleHookValue<WledModule>;
 
 const WledContext = createContext<WledHookValue>({} as WledHookValue);
 
-setTimeout(() => {
-    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
-        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
-            return new WledModule(coreDeps, modDependencies);
-        });
+jamtools.registerClassModule((coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+    return new WledModule(coreDeps, modDependencies);
 });
 
 declare module '~/module_registry/module_registry' {

--- a/apps/jamtools/core/peripherals/outputs/soundfont_peripheral.tsx
+++ b/apps/jamtools/core/peripherals/outputs/soundfont_peripheral.tsx
@@ -14,6 +14,12 @@ type HeldDownSoundfontNotes = {
     player: Soundfont.Player
 };
 
+declare module '~/modules/macro_module/macro_module_types' {
+    interface ProducedTypeMap {
+        musical_keyboard_output: OutputMidiDevice;
+    }
+}
+
 export class SoundfontPeripheral implements OutputMidiDevice {
     constructor(private coreDeps: CoreDependencies, private moduleDeps: ModuleDependencies) {
 

--- a/apps/jamtools/core/peripherals/outputs/soundfont_peripheral.tsx
+++ b/apps/jamtools/core/peripherals/outputs/soundfont_peripheral.tsx
@@ -28,6 +28,8 @@ export class SoundfontPeripheral implements OutputMidiDevice {
     };
 
     public initialize = async () => {
+        // TODO: serve the soundfont file from origin instead of fetching from CDN. would probably need to fork or do babel transformation since the url is hardcoded
+        // https://github.com/danigb/soundfont-player/blob/2b89587d7cc396c5c7b91056f8cb78831ead7436/dist/soundfont-player.js#L76
         this.soundfont = await Soundfont.instrument(new AudioContext(), 'acoustic_grand_piano');
     };
 

--- a/apps/jamtools/core/types/module_types.ts
+++ b/apps/jamtools/core/types/module_types.ts
@@ -1,6 +1,12 @@
-import {ModuleRegistry} from '~/module_registry/module_registry';
+import {Module, ModuleRegistry} from '~/module_registry/module_registry';
 import {MidiService, QwertyService} from './io_types';
-import {ProducedType, RegisteredMacroConfigItems} from '~/modules/macro_module/macro_module_types';
+
+export type ModuleCallback<T extends object,> = (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) =>
+Promise<Module<T>> | Module<T>;
+export type JamTools = {
+    registerClassModule: <T extends object>(cb: ModuleCallback<T>) => void;
+    registerClassModulee: <T extends object>(cb: ModuleCallback<T>) => void;
+};
 
 export type CoreDependencies = {
     log: (...s: any[]) => void;

--- a/apps/jamtools/server/src/express_app.ts
+++ b/apps/jamtools/server/src/express_app.ts
@@ -1,6 +1,9 @@
 import path from 'path';
+import {WebSocketServer, WebSocket} from 'ws';
 
 import express from 'express';
+
+import {NodeJsonRpcServer} from './services/node_json_rpc';
 
 export const initApp = () => {
     const app = express();
@@ -9,6 +12,10 @@ export const initApp = () => {
 
     const webappFolder = path.join(__dirname, '../../webapp');
     const webappDistFolder = path.join(webappFolder, './dist');
+
+    const wss = new WebSocketServer({port: 8080});
+    const service = new NodeJsonRpcServer(wss);
+    service.initialize();
 
     router.get('/', (req, res) => {
         res.setHeader('Content-Type', 'text/html');

--- a/apps/jamtools/server/src/services/node_json_rpc.ts
+++ b/apps/jamtools/server/src/services/node_json_rpc.ts
@@ -7,6 +7,8 @@ type RpcClient = ModuleDependencies['rpc'];
 export class NodeJsonRpcServer implements RpcClient {
     rpcClient!: JSONRPCClient;
 
+    constructor(private wss: WebSocketServer) {}
+
     callRpc = async <Return, Args>(method: string, args: Args): Promise<Return> => {
         const result = await this.rpcClient.request(method, args);
         return result;
@@ -17,7 +19,8 @@ export class NodeJsonRpcServer implements RpcClient {
     };
 
     initialize = async () => {
-        const wss = new WebSocketServer({port: 8080});
+        const wss = this.wss;
+        // const wss = new WebSocketServer({port: 8080});
 
         const jsonRpcServer = new JSONRPCServer();
 
@@ -78,6 +81,3 @@ export class NodeJsonRpcServer implements RpcClient {
         console.log('WebSocket server is running on ws://localhost:8080');
     };
 }
-
-const service = new NodeJsonRpcServer();
-service.initialize();

--- a/apps/jamtools/webapp/index.html
+++ b/apps/jamtools/webapp/index.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Jam your socks off with this all-in-one music performance system to help you bring your improvisations and creations to the next level.">
+
+    <style>body{font-family: system-ui}</style>
 </head>
 
 <body>

--- a/apps/jamtools/webapp/snacks/root_mode_snack/root_mode_snack.tsx
+++ b/apps/jamtools/webapp/snacks/root_mode_snack/root_mode_snack.tsx
@@ -7,9 +7,19 @@ import {useSubject} from '~/module_registry/module_registry';
 import {ScaleDegreeInfo, cycle, getScaleDegreeFromScaleAndNote} from './root_mode_types';
 
 import {RootModeComponent} from './root_mode_component';
+import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_types';
 
 setTimeout(() => {
-    main();
+    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
+        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+            return rootModeModule(coreDeps, modDependencies);
+        });
+});
+
+setTimeout(async () => {
+    const engine = await startJamToolsAndRenderApp();
+
+    // main();
 });
 
 type State = {
@@ -28,49 +38,8 @@ const rootModeStateSubject: Subject<State> = new Subject();
 // this makes it so all midi and soundfont type stuff is ignored
 // basically disables the io module, or at least makes it so it doesn't dispatch anything
 
-const main = async () => {
-    console.log('running snack: root mode');
-
-    const engine = await startJamToolsAndRenderApp();
-    const macroModule = engine.moduleRegistry.getModule('macro');
-
-    const [input, output] = await Promise.all([
-        macroModule.createMacro('MIDI Input', {type: 'musical_keyboard_input'}),
-        macroModule.createMacro('MIDI Output', {type: 'musical_keyboard_output'}),
-    ]);
-
+const rootModeModule = async (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
     let scale = 0; // C major on page load
-
-    input.onEventSubject.subscribe(evt => {
-        const midiNumber = evt.event.number;
-        const scaleDegreeInfo = getScaleDegreeFromScaleAndNote(scale, midiNumber);
-        if (!scaleDegreeInfo) {
-            return;
-        }
-
-        const chordNotes = getChordFromRootNote(scale, midiNumber);
-        if (!chordNotes.length) {
-            return;
-        }
-
-        for (const noteNumber of chordNotes) {
-            const midiNumberToPlay = noteNumber + 24;
-            output.send({...evt.event, number: midiNumberToPlay});
-        }
-
-        if (evt.event.type === 'noteon') {
-            rootModeStateSubject.next({
-                chord: scaleDegreeInfo,
-                scale,
-            });
-        } else if (evt.event.type === 'noteoff') {
-            // this naive logic is currently causing the second chord to disappear if the first one is released after pressing the second one
-            rootModeStateSubject.next({
-                chord: null,
-                scale,
-            });
-        }
-    });
 
     const setScale = (newScale: number) => {
         scale = newScale;
@@ -80,7 +49,7 @@ const main = async () => {
         });
     }
 
-    engine.moduleRegistry.registerModule({
+    return {
         moduleId: 'root_mode_snack',
         routes: {
             '': () => {
@@ -98,7 +67,50 @@ const main = async () => {
                 );
             },
         },
-    });
+        initialize: async () => {
+            console.log('running snack: root mode');
+
+            const macroModule = modDependencies.moduleRegistry.getModule('macro');
+
+            const [input, output] = await Promise.all([
+                macroModule.createMacro('MIDI Input', {type: 'musical_keyboard_input'}),
+                macroModule.createMacro('MIDI Output', {type: 'musical_keyboard_output'}),
+            ]);
+
+            input.onEventSubject.subscribe(evt => {
+                const midiNumber = evt.event.number;
+                const scaleDegreeInfo = getScaleDegreeFromScaleAndNote(scale, midiNumber);
+                if (!scaleDegreeInfo) {
+                    return;
+                }
+
+                const chordNotes = getChordFromRootNote(scale, midiNumber);
+                if (!chordNotes.length) {
+                    return;
+                }
+
+                for (const noteNumber of chordNotes) {
+                    const midiNumberToPlay = noteNumber + 24;
+                    output.send({...evt.event, number: midiNumberToPlay});
+                }
+
+                if (evt.event.type === 'noteon') {
+                    rootModeStateSubject.next({
+                        chord: scaleDegreeInfo,
+                        scale,
+                    });
+                } else if (evt.event.type === 'noteoff') {
+                    // this naive logic is currently causing the second chord to disappear if the first one is released after pressing the second one
+                    rootModeStateSubject.next({
+                        chord: null,
+                        scale,
+                    });
+                }
+            });
+
+
+        }
+    };
 };
 
 const getChordFromRootNote = (scale: number, rootNote: number): number[] => {

--- a/apps/jamtools/webapp/snacks/root_mode_snack/root_mode_snack.tsx
+++ b/apps/jamtools/webapp/snacks/root_mode_snack/root_mode_snack.tsx
@@ -8,12 +8,10 @@ import {ScaleDegreeInfo, cycle, getScaleDegreeFromScaleAndNote} from './root_mod
 
 import {RootModeComponent} from './root_mode_component';
 import {CoreDependencies, JamTools, ModuleDependencies} from '~/types/module_types';
+import {jamtools} from '~/engine/register';
 
-setTimeout(() => {
-    (globalThis as unknown as {jamtools: JamTools}).jamtools.registerClassModule(
-        (coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
-            return rootModeModule(coreDeps, modDependencies);
-        });
+jamtools.registerClassModule((coreDeps: CoreDependencies, modDependencies: ModuleDependencies) => {
+    return rootModeModule(coreDeps, modDependencies);
 });
 
 setTimeout(async () => {

--- a/apps/jamtools/webapp/src/services/browser_qwerty_service.ts
+++ b/apps/jamtools/webapp/src/services/browser_qwerty_service.ts
@@ -7,14 +7,14 @@ export class BrowserQwertyService implements QwertyService {
         document.addEventListener('keydown', (event) => {
             this.onInputEvent.next({
                 event: 'keydown',
-                key: event.key,
+                key: event.key.toLowerCase(),
             });
         });
 
         document.addEventListener('keyup', (event) => {
             this.onInputEvent.next({
                 event: 'keyup',
-                key: event.key,
+                key: event.key.toLowerCase(),
             });
         });
     }

--- a/configs/.eslintrc.js
+++ b/configs/.eslintrc.js
@@ -30,7 +30,8 @@ module.exports = {
         indent: 'off',
         '@typescript-eslint/indent': ['error'],
         '@typescript-eslint/no-explicit-any': 'off',
-        "no-empty-function": ['warn'],
+        'no-empty-function': ['warn'],
+        '@typescript-eslint/ban-types': 'off',
         quotes: [
             'error',
             'single'


### PR DESCRIPTION
Introduced [engine/register.ts](https://github.com/jamtools/jamtools/blob/4628e25341cdbc8f9b0adeaa75bf0a52161e2202/apps/jamtools/core/engine/register.ts) which is effectively the global entrypoint of any module/snack/macro registration. This has de-centralized the individual modules so the engine doesn't need to reference or instantiate them directly. Not much has changed in terms of functionality though