### PR TITLE
WIP: Introduce `defineModule` function to declare a module before registering

### DIFF
--- a/apps/springboard-test/index.ts
+++ b/apps/springboard-test/index.ts
@@ -1,0 +1,31 @@
+import {Springboard} from 'springboard/engine/engine';
+import {springboard} from 'springboard/engine/register';
+
+const mod = springboard.defineModule('Main', {
+    externalDependencies: {
+        mything: async () => {
+            return {
+                getTheThing: async () => 'thanks',
+            };
+        },
+    },
+}, async (m, deps) => {
+    const myThing = await deps.externalDependencies.mything();
+
+    // const macroModule = m.getModule('macro');
+});
+
+const engine = new Springboard({} as any, {});
+
+engine.registerModule2(mod);
+engine.registerModule2(mod, {
+    externalDependencies: {
+        mything: async () => {
+            return {
+                getTheThing: async () => {
+                    return 'fegfeg';
+                },
+            }
+        }
+    }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13397,7 +13397,7 @@
     },
     "packages/jamtools/core": {
       "name": "@jamtools/core",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "easymidi": "^3.0.1",
         "midi-file": "^1.2.4",
@@ -13407,12 +13407,12 @@
       "devDependencies": {},
       "peerDependencies": {
         "@tonejs/midi": "^2.0.0",
-        "springboard": "0.14.0"
+        "springboard": "0.14.1"
       }
     },
     "packages/jamtools/features": {
       "name": "@jamtools/features",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "jsdom": "^25.0.0",
         "qrcode": "^1.5.4",
@@ -13424,8 +13424,8 @@
         "@types/qrcode": "^1.5.5"
       },
       "peerDependencies": {
-        "@jamtools/core": "0.14.0",
-        "@springboardjs/shoelace": "0.14.0"
+        "@jamtools/core": "0.14.1",
+        "@springboardjs/shoelace": "0.14.1"
       }
     },
     "packages/observability": {
@@ -13441,7 +13441,7 @@
     },
     "packages/springboard/cli": {
       "name": "springboard-cli",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "ISC",
       "dependencies": {
         "commander": "^12.1.0",
@@ -13459,15 +13459,15 @@
         "tsx": "^4.19.2"
       },
       "peerDependencies": {
-        "@springboardjs/platforms-browser": "0.14.0",
-        "@springboardjs/platforms-node": "0.14.0",
-        "springboard": "0.14.0",
-        "springboard-server": "0.14.0"
+        "@springboardjs/platforms-browser": "0.14.1",
+        "@springboardjs/platforms-node": "0.14.1",
+        "springboard": "0.14.1",
+        "springboard-server": "0.14.1"
       }
     },
     "packages/springboard/core": {
       "name": "springboard",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "dexie": "^4.0.9",
         "immer": "^10.1.1",
@@ -13490,7 +13490,7 @@
     },
     "packages/springboard/data_storage": {
       "name": "@springboardjs/data-storage",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "ISC",
       "dependencies": {
         "@trpc/client": "^10.45.2",
@@ -13508,7 +13508,7 @@
     },
     "packages/springboard/external/mantine": {
       "name": "@springboardjs/mantine",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "ISC",
       "peerDependencies": {
         "@mantine/core": "^7.13.4",
@@ -13516,49 +13516,49 @@
         "@mantine/hooks": "^7.13.4",
         "@mantine/modals": "^7.13.4",
         "@mantine/notifications": "^7.13.4",
-        "springboard": "0.14.0"
+        "springboard": "0.14.1"
       }
     },
     "packages/springboard/external/shoelace": {
       "name": "@springboardjs/shoelace",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "ISC",
       "dependencies": {
         "@shoelace-style/shoelace": "^2.16.0"
       },
       "peerDependencies": {
-        "springboard": "0.14.0"
+        "springboard": "0.14.1"
       }
     },
     "packages/springboard/platforms/node": {
       "name": "@springboardjs/platforms-node",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "peerDependencies": {
         "isomorphic-ws": "^4.0.1",
-        "springboard": "0.14.0",
+        "springboard": "0.14.1",
         "ws": "^8.18.0"
       }
     },
     "packages/springboard/platforms/webapp": {
       "name": "@springboardjs/platforms-browser",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "peerDependencies": {
         "react-router-dom": "^6",
-        "springboard": "0.14.0"
+        "springboard": "0.14.1"
       }
     },
     "packages/springboard/server": {
       "name": "springboard-server",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@hono/node-server": "^1.13.2",
         "@hono/node-ws": "^1.0.4",
         "@hono/trpc-server": "^0.3.2"
       },
       "peerDependencies": {
-        "@springboardjs/data-storage": "0.14.0",
+        "@springboardjs/data-storage": "0.14.1",
         "hono": "^4.6.7",
-        "springboard": "0.14.0"
+        "springboard": "0.14.1"
       }
     }
   }

--- a/packages/jamtools/core/modules/io/io_module.tsx
+++ b/packages/jamtools/core/modules/io/io_module.tsx
@@ -24,33 +24,33 @@ let createIoDependencies = (): IoDeps => {
     };
 };
 
-// @platform "browser"
-import {BrowserQwertyService} from '@jamtools/core/services/browser/browser_qwerty_service';
-import {BrowserMidiService} from '@jamtools/core/services/browser/browser_midi_service';
+// // @platform "browser"
+// import {BrowserQwertyService} from '@jamtools/core/services/browser/browser_qwerty_service';
+// import {BrowserMidiService} from '@jamtools/core/services/browser/browser_midi_service';
 
-createIoDependencies = () => {
-    const qwerty = new BrowserQwertyService(document);
-    const midi = new BrowserMidiService();
-    return {
-        qwerty,
-        midi,
-    };
-};
-// @platform end
+// createIoDependencies = () => {
+//     const qwerty = new BrowserQwertyService(document);
+//     const midi = new BrowserMidiService();
+//     return {
+//         qwerty,
+//         midi,
+//     };
+// };
+// // @platform end
 
-// @platform "node"
-import {NodeQwertyService} from '@jamtools/core/services/node/node_qwerty_service';
-import {NodeMidiService} from '@jamtools/core/services/node/node_midi_service';
+// // @platform "node"
+// import {NodeQwertyService} from '@jamtools/core/services/node/node_qwerty_service';
+// import {NodeMidiService} from '@jamtools/core/services/node/node_midi_service';
 
-createIoDependencies = () => {
-    const qwerty = new NodeQwertyService();
-    const midi = new NodeMidiService();
-    return {
-        qwerty,
-        midi,
-    };
-};
-// @platform end
+// createIoDependencies = () => {
+//     const qwerty = new NodeQwertyService();
+//     const midi = new NodeMidiService();
+//     return {
+//         qwerty,
+//         midi,
+//     };
+// };
+// // @platform end
 
 export const setIoDependencyCreator = (func: typeof createIoDependencies) => {
     createIoDependencies = func;


### PR DESCRIPTION
In order to make the initialization process more explicit, and facilitate dependency injection more easily, we are pivoting to explicit registering of modules instead of implicit registering through side effect imports.