### PR TITLE
Make macro module support local midi device mode

### DIFF
--- a/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/input_macro_handler_utils.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/input_macro_handler_utils.tsx
@@ -53,11 +53,11 @@ export const useInputMacroWaiterAndSaver = async (
     const savedMidiEvents = states.savedMidiEvents;
 
     if (savedMidiEvents.getState().length) {
-        macroAPI.moduleAPI.getModule('io').ensureListening();
+        macroAPI.midiIO.ensureListening();
     }
 
     const createAction = <Args extends object>(actionName: string, cb: (args: Args) => void) => {
-        return macroAPI.moduleAPI.createAction(`macro|${fieldName}|${actionName}`, {}, async (args: Args) => {
+        return macroAPI.createAction(`macro|${fieldName}|${actionName}`, {}, async (args: Args) => {
             return cb(args);
         });
     };
@@ -65,7 +65,7 @@ export const useInputMacroWaiterAndSaver = async (
     const toggleWaiting = createAction('toggle_waiting_input', async () => {
         const currentlyWaiting = waitingForConfiguration.getState();
         if (!currentlyWaiting) {
-            macroAPI.moduleAPI.getModule('io').ensureListening();
+            macroAPI.midiIO.ensureListening();
         }
 
         waitingForConfiguration.setState(!currentlyWaiting);
@@ -146,7 +146,7 @@ export const useInputMacroWaiterAndSaver = async (
         },
     };
 
-    if (!macroAPI.moduleAPI.deps.core.isMaestro()) {
+    if (!macroAPI.isMidiMaestro()) {
         return returnValue;
     }
 

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/midi_button_input_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/midi_button_input_macro_handler.tsx
@@ -32,10 +32,10 @@ declare module '../../macro_module_types' {
 }
 
 macroTypeRegistry.registerMacroType('midi_button_input', {}, async (macroAPI, conf, fieldName) => {
-    const editing = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
-    const waitingForConfiguration = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('waiting_for_configuration', fieldName), false);
-    const capturedMidiEvent = await macroAPI.moduleAPI.statesAPI.createSharedState<MidiEventFull | null>(getKeyForMacro('captured_midi_event', fieldName), null);
-    const savedMidiEvents = await macroAPI.moduleAPI.statesAPI.createPersistentState<MidiEventFull[]>(getKeyForMacro('saved_midi_event', fieldName), []);
+    const editing = await macroAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
+    const waitingForConfiguration = await macroAPI.statesAPI.createSharedState(getKeyForMacro('waiting_for_configuration', fieldName), false);
+    const capturedMidiEvent = await macroAPI.statesAPI.createSharedState<MidiEventFull | null>(getKeyForMacro('captured_midi_event', fieldName), null);
+    const savedMidiEvents = await macroAPI.statesAPI.createPersistentState<MidiEventFull[]>(getKeyForMacro('saved_midi_event', fieldName), []);
     const states: InputMacroStateHolders = {
         editing,
         waiting: waitingForConfiguration,
@@ -45,7 +45,7 @@ macroTypeRegistry.registerMacroType('midi_button_input', {}, async (macroAPI, co
 
     const initialMacroReturnValue = await useInputMacroWaiterAndSaver(macroAPI, states, {includeQwerty: conf.enableQwerty}, fieldName, savedMidiEventsAreEqual);
 
-    const onPress = macroAPI.moduleAPI.createAction(getKeyForMacro('onPress', fieldName), {}, async () => {
+    const onPress = macroAPI.createAction(getKeyForMacro('onPress', fieldName), {}, async () => {
         const event: MidiEventFull = {
             type: 'ui',
             deviceInfo: {
@@ -79,7 +79,7 @@ macroTypeRegistry.registerMacroType('midi_button_input', {}, async (macroAPI, co
         }
     };
 
-    if (!macroAPI.moduleAPI.deps.core.isMaestro()) {
+    if (!macroAPI.isMidiMaestro()) {
         return macroReturnValue;
     }
 
@@ -114,11 +114,11 @@ macroTypeRegistry.registerMacroType('midi_button_input', {}, async (macroAPI, co
         }
     };
 
-    const midiSubscription = macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('io').midiInputSubject.subscribe(handleMidiEvent);
+    const midiSubscription = macroAPI.midiIO.midiInputSubject.subscribe(handleMidiEvent);
     macroAPI.onDestroy(midiSubscription.unsubscribe);
 
     if (conf.enableQwerty) {
-        const qwertySubscription = macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('io').qwertyInputSubject.subscribe((qwertyEvent => {
+        const qwertySubscription = macroAPI.midiIO.qwertyInputSubject.subscribe((qwertyEvent => {
             const midiEvent = qwertyEventToMidiEvent(qwertyEvent, false);
             if (!midiEvent) {
                 return;

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/midi_control_change_input_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/midi_control_change_input_macro_handler.tsx
@@ -22,10 +22,10 @@ declare module '../../macro_module_types' {
 }
 
 macroTypeRegistry.registerMacroType('midi_control_change_input', {}, async (macroAPI, conf, fieldName) => {
-    const editing = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
-    const waitingForConfiguration = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('waiting_for_configuration', fieldName), false);
-    const capturedMidiEvent = await macroAPI.moduleAPI.statesAPI.createSharedState<MidiEventFull | null>(getKeyForMacro('captured_midi_event', fieldName), null);
-    const savedMidiEvents = await macroAPI.moduleAPI.statesAPI.createPersistentState<MidiEventFull[]>(getKeyForMacro('saved_midi_event', fieldName), []);
+    const editing = await macroAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
+    const waitingForConfiguration = await macroAPI.statesAPI.createSharedState(getKeyForMacro('waiting_for_configuration', fieldName), false);
+    const capturedMidiEvent = await macroAPI.statesAPI.createSharedState<MidiEventFull | null>(getKeyForMacro('captured_midi_event', fieldName), null);
+    const savedMidiEvents = await macroAPI.statesAPI.createPersistentState<MidiEventFull[]>(getKeyForMacro('saved_midi_event', fieldName), []);
     const states: InputMacroStateHolders = {
         editing,
         waiting: waitingForConfiguration,
@@ -35,11 +35,11 @@ macroTypeRegistry.registerMacroType('midi_control_change_input', {}, async (macr
 
     const macroReturnValue = await useInputMacroWaiterAndSaver(macroAPI, states, {}, fieldName, savedMidiEventsAreEqual);
 
-    if (!macroAPI.moduleAPI.deps.core.isMaestro() && !conf.allowLocal) {
+    if (!macroAPI.isMidiMaestro() && !conf.allowLocal) {
         return macroReturnValue;
     }
 
-    const sub = macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('io').midiInputSubject.subscribe(event => {
+    const sub = macroAPI.midiIO.midiInputSubject.subscribe(event => {
         if (event.event.type !== 'cc') {
             return;
         }

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/musical_keyboard_input_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/musical_keyboard_input_macro_handler.tsx
@@ -35,10 +35,10 @@ macroTypeRegistry.registerMacroType(
     'musical_keyboard_input',
     {},
     async (macroAPI, conf, fieldName): Promise<MusicalKeyboardInputResult> => {
-        const editing = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
-        const waitingForConfiguration = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('waiting_for_configuration', fieldName), false);
-        const capturedMidiEvent = await macroAPI.moduleAPI.statesAPI.createSharedState<MidiEventFull | null>(getKeyForMacro('captured_midi_event', fieldName), null);
-        const savedMidiEvents = await macroAPI.moduleAPI.statesAPI.createPersistentState<MidiEventFull[]>(getKeyForMacro('saved_midi_event', fieldName), []);
+        const editing = await macroAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
+        const waitingForConfiguration = await macroAPI.statesAPI.createSharedState(getKeyForMacro('waiting_for_configuration', fieldName), false);
+        const capturedMidiEvent = await macroAPI.statesAPI.createSharedState<MidiEventFull | null>(getKeyForMacro('captured_midi_event', fieldName), null);
+        const savedMidiEvents = await macroAPI.statesAPI.createPersistentState<MidiEventFull[]>(getKeyForMacro('saved_midi_event', fieldName), []);
         const states: InputMacroStateHolders = {
             editing,
             waiting: waitingForConfiguration,
@@ -52,7 +52,7 @@ macroTypeRegistry.registerMacroType(
             ...macroReturnValueFromSaver,
         };
 
-        if (!macroAPI.moduleAPI.deps.core.isMaestro()) {
+        if (!macroAPI.isMidiMaestro()) {
             return macroReturnValue;
         }
 
@@ -87,11 +87,11 @@ macroTypeRegistry.registerMacroType(
             }
         };
 
-        const midiSubscription = macroAPI.moduleAPI.getModule('io').midiInputSubject.subscribe(handleMidiEvent);
+        const midiSubscription = macroAPI.midiIO.midiInputSubject.subscribe(handleMidiEvent);
         macroAPI.onDestroy(midiSubscription.unsubscribe);
 
         if (conf.enableQwerty) {
-            const qwertySubscription = macroAPI.moduleAPI.getModule('io').qwertyInputSubject.subscribe((qwertyEvent => {
+            const qwertySubscription = macroAPI.midiIO.qwertyInputSubject.subscribe((qwertyEvent => {
                 const midiEvent = qwertyEventToMidiEvent(qwertyEvent, true);
                 if (!midiEvent) {
                     return;

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/musical_keyboard_paged_octave_input_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/inputs/musical_keyboard_paged_octave_input_macro_handler.tsx
@@ -53,9 +53,9 @@ macroTypeRegistry.registerMacroType(
             numberOfOctaves: conf.singleOctave ? 1 : initialUserDefinedConfig.numberOfOctaves,
         };
 
-        const pagedOctaveInputStoredConfig = await macroAPI.moduleAPI.statesAPI.createPersistentState<PagedOctaveInputStoredConfig>(getKeyForMacro('pagedOctaveInputStoredConfig', fieldName), initialUserConfig);
+        const pagedOctaveInputStoredConfig = await macroAPI.statesAPI.createPersistentState<PagedOctaveInputStoredConfig>(getKeyForMacro('pagedOctaveInputStoredConfig', fieldName), initialUserConfig);
 
-        const showConfigurationFormState = await macroAPI.moduleAPI.statesAPI.createSharedState<boolean>(getKeyForMacro('pagedOctaveInputShowForm', fieldName), false);
+        const showConfigurationFormState = await macroAPI.statesAPI.createSharedState<boolean>(getKeyForMacro('pagedOctaveInputShowForm', fieldName), false);
 
         const subject = new Subject<MidiEventFull>();
 
@@ -66,10 +66,9 @@ macroTypeRegistry.registerMacroType(
             macroAPI.onDestroy(subscription.unsubscribe);
         }
 
-        const keyboardMacro = await macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('macro').createMacro(macroAPI.moduleAPI, fieldName + '|keyboard_input', 'musical_keyboard_input', {enableQwerty: conf.enableQwerty});
+        const keyboardMacro = await macroAPI.createMacro(macroAPI.moduleAPI, fieldName + '|keyboard_input', 'musical_keyboard_input', {enableQwerty: conf.enableQwerty});
 
-
-        const pageDownMacro = await macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('macro').createMacro(macroAPI.moduleAPI, fieldName + '|page_down', 'midi_button_input', {
+        const pageDownMacro = await macroAPI.createMacro(macroAPI.moduleAPI, fieldName + '|page_down', 'midi_button_input', {
             includeRelease: false,
             onTrigger: () => {
                 const currentConfig = pagedOctaveInputStoredConfig.getState();
@@ -82,7 +81,7 @@ macroTypeRegistry.registerMacroType(
             },
         });
 
-        const pageUpMacro = await macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('macro').createMacro(macroAPI.moduleAPI, fieldName + '|page_up', 'midi_button_input', {
+        const pageUpMacro = await macroAPI.createMacro(macroAPI.moduleAPI, fieldName + '|page_up', 'midi_button_input', {
             includeRelease: false,
             onTrigger: () => {
                 const currentConfig = pagedOctaveInputStoredConfig.getState();
@@ -95,7 +94,7 @@ macroTypeRegistry.registerMacroType(
             },
         });
 
-        const submitNumberOfOctaves = macroAPI.moduleAPI.createAction(getKeyForMacro('pagedInput|submitNumberOfOctaves', fieldName), {}, async (args: {numberOfOctaves: number}) => {
+        const submitNumberOfOctaves = macroAPI.createAction(getKeyForMacro('pagedInput|submitNumberOfOctaves', fieldName), {}, async (args: {numberOfOctaves: number}) => {
             const currentConfig = pagedOctaveInputStoredConfig.getState();
 
             const newState = produce(currentConfig, (draft => {

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/midi_button_output_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/midi_button_output_macro_handler.tsx
@@ -27,9 +27,9 @@ macroTypeRegistry.registerMacroType(
     'midi_button_output',
     {},
     (async (macroAPI, inputConf, fieldName) => {
-        const editingState = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
-        const addingOutputDevice = await macroAPI.moduleAPI.statesAPI.createSharedState<AddingOutputDeviceState>(getKeyForMacro('adding_output_device', fieldName), {device: null, channel: null});
-        const savedOutputDevices = await macroAPI.moduleAPI.statesAPI.createPersistentState<SavedOutputDeviceState[]>(getKeyForMacro('saved_output_devices', fieldName), []);
+        const editingState = await macroAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
+        const addingOutputDevice = await macroAPI.statesAPI.createSharedState<AddingOutputDeviceState>(getKeyForMacro('adding_output_device', fieldName), {device: null, channel: null});
+        const savedOutputDevices = await macroAPI.statesAPI.createPersistentState<SavedOutputDeviceState[]>(getKeyForMacro('saved_output_devices', fieldName), []);
 
         const states: OutputMacroStateHolders = {
             editing: editingState,
@@ -39,7 +39,7 @@ macroTypeRegistry.registerMacroType(
 
         const macroReturnValue = await useOutputMacroWaiterAndSaver(macroAPI, states, {includeNote: true}, fieldName, checkSavedMidiOutputsAreEqual);
 
-        const ioModule = macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('io');
+        const ioModule = macroAPI.midiIO;
 
         const send = (args: {release: boolean} | {releaseTimeout: number}) => {
             const saved = savedOutputDevices.getState();

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/midi_control_change_output_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/midi_control_change_output_macro_handler.tsx
@@ -28,9 +28,9 @@ macroTypeRegistry.registerMacroType(
     'midi_control_change_output',
     {},
     (async (macroAPI, inputConf, fieldName) => {
-        const editingState = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
-        const addingOutputDevice = await macroAPI.moduleAPI.statesAPI.createSharedState<AddingOutputDeviceState>(getKeyForMacro('adding_output_device', fieldName), {device: null, channel: null});
-        const savedOutputDevices = await macroAPI.moduleAPI.statesAPI.createPersistentState<SavedOutputDeviceState[]>(getKeyForMacro('saved_output_devices', fieldName), []);
+        const editingState = await macroAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
+        const addingOutputDevice = await macroAPI.statesAPI.createSharedState<AddingOutputDeviceState>(getKeyForMacro('adding_output_device', fieldName), {device: null, channel: null});
+        const savedOutputDevices = await macroAPI.statesAPI.createPersistentState<SavedOutputDeviceState[]>(getKeyForMacro('saved_output_devices', fieldName), []);
 
         const states: OutputMacroStateHolders = {
             editing: editingState,
@@ -40,7 +40,7 @@ macroTypeRegistry.registerMacroType(
 
         const macroReturnValue = await useOutputMacroWaiterAndSaver(macroAPI, states, {includeNote: true}, fieldName, checkSavedMidiOutputsAreEqual);
 
-        const ioModule = macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('io');
+        const ioModule = macroAPI.midiIO;
 
         const send = (value: number) => {
             const saved = savedOutputDevices.getState();

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/musical_keyboard_output_macro_handler.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/musical_keyboard_output_macro_handler.tsx
@@ -22,9 +22,9 @@ macroTypeRegistry.registerMacroType(
     'musical_keyboard_output',
     {},
     (async (macroAPI, inputConf, fieldName) => {
-        const editingState = await macroAPI.moduleAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
-        const addingOutputDevice = await macroAPI.moduleAPI.statesAPI.createSharedState<AddingOutputDeviceState>(getKeyForMacro('adding_output_device', fieldName), {device: null, channel: null});
-        const savedOutputDevices = await macroAPI.moduleAPI.statesAPI.createPersistentState<SavedOutputDeviceState[]>(getKeyForMacro('saved_output_devices', fieldName), []);
+        const editingState = await macroAPI.statesAPI.createSharedState(getKeyForMacro('editing', fieldName), false);
+        const addingOutputDevice = await macroAPI.statesAPI.createSharedState<AddingOutputDeviceState>(getKeyForMacro('adding_output_device', fieldName), {device: null, channel: null});
+        const savedOutputDevices = await macroAPI.statesAPI.createPersistentState<SavedOutputDeviceState[]>(getKeyForMacro('saved_output_devices', fieldName), []);
 
         const states: OutputMacroStateHolders = {
             editing: editingState,

--- a/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/output_macro_handler_utils.tsx
+++ b/packages/jamtools/core/modules/macro_module/macro_handlers/outputs/output_macro_handler_utils.tsx
@@ -28,11 +28,11 @@ type OutputMacroSaverOptions = {
 type CheckSavedMidiOutputsAreEqual = (state1: SavedOutputDeviceState, state2: SavedOutputDeviceState) => boolean;
 
 export const useOutputMacroWaiterAndSaver = async (macroAPI: MacroAPI, states: OutputMacroStateHolders, options: OutputMacroSaverOptions, fieldName: string, checkSavedMidiOutputsAreEqual: CheckSavedMidiOutputsAreEqual): Promise<MidiOutputMacroPayload> => {
-    const ioModule = macroAPI.moduleAPI.deps.module.moduleRegistry.getModule('io');
+    const ioModule = macroAPI.midiIO;
     const editingState = states.editing;
 
     const createAction = <Args extends object>(actionName: string, cb: (args: Args) => void) => {
-        return macroAPI.moduleAPI.createAction(`macro|${fieldName}|${actionName}`, {}, async (args: Args) => {
+        return macroAPI.createAction(`macro|${fieldName}|${actionName}`, {}, async (args: Args) => {
             return cb(args);
         });
     };

--- a/packages/jamtools/core/modules/macro_module/registered_macro_types.ts
+++ b/packages/jamtools/core/modules/macro_module/registered_macro_types.ts
@@ -1,6 +1,8 @@
-import {ModuleAPI} from 'springboard/engine/module_api';
+import {ModuleAPI, StatesAPI} from 'springboard/engine/module_api';
 
 import type {MacroTypeConfigs} from './macro_module_types';
+import {IoModule} from '../io/io_module';
+import type {MacroModule} from './macro_module';
 
 export type RegisterMacroTypeOptions = {
 
@@ -8,7 +10,12 @@ export type RegisterMacroTypeOptions = {
 
 export type MacroAPI = {
     moduleAPI: ModuleAPI;
+    midiIO: IoModule;
+    statesAPI: Pick<StatesAPI, 'createSharedState' | 'createPersistentState'>;
+    createAction: ModuleAPI['createAction'];
+    isMidiMaestro: () => boolean;
     onDestroy: (cb: () => void) => void;
+    createMacro: MacroModule['createMacro'];
 };
 
 export type MacroCallback<MacroInputConf extends object, MacroReturnValue extends object> = (macroAPI: MacroAPI, macroInputConf: MacroInputConf, fieldName: string) =>

--- a/packages/jamtools/features/modules/hand_raiser_module.tsx
+++ b/packages/jamtools/features/modules/hand_raiser_module.tsx
@@ -5,17 +5,10 @@ import springboard from 'springboard';
 
 import './hand_raiser.css';
 
-// how to handle local midi device stuff in remote context
-// eventually I think this will be done through spawnables
-
-// for now, the macro module will need to manually pivot and make its own concept of spawnables
-// the user chooses to use a local midi device, and the macro module takes care of the complexity
-// instead of `moduleAPI.createActions`, the module uses `moduleAPI.actions.createHybridAction`
-// idk about that actually. it can probably use createActions still, with {client: true} in the call
-// but based on user choice, the macro will use remote actions&state, or local actions&state
-// so it will use a user agent state supervisor for local
-
 springboard.registerModule('HandRaiser', {}, async (m) => {
+    const macroModule = m.getModule('macro');
+    macroModule.setLocalMode(true);
+
     const states = await m.createStates({
         handPositions: [0, 0],
     });
@@ -28,7 +21,6 @@ springboard.registerModule('HandRaiser', {}, async (m) => {
         },
     });
 
-    const macroModule = m.getModule('macro');
     const macros = await macroModule.createMacros(m, {
         slider0: {
             type: 'midi_control_change_input',

--- a/packages/springboard/platforms/webapp/services/browser_json_rpc.ts
+++ b/packages/springboard/platforms/webapp/services/browser_json_rpc.ts
@@ -78,6 +78,9 @@ export class BrowserJsonRpcClientAndServer implements Rpc {
 
         ws.onmessage = async (event) => {
             const jsonMessage = JSON.parse(event.data);
+            if (!jsonMessage) {
+                return;
+            }
 
             if (jsonMessage.jsonrpc === '2.0' && jsonMessage.method) {
                 // Handle incoming RPC requests coming from the server to run in this client


### PR DESCRIPTION
This PR makes it so MIDI apps can be written in a way where the MIDI devices are used in the client. Whereas the default behavior in jamtools is that the server (usually a "desktop app server") is the "MIDI host", and the clients are presentation-only. Now you can deploy remote multiplayer apps and allow clients to use MIDI devices.